### PR TITLE
add url support

### DIFF
--- a/lib/esConnector.js
+++ b/lib/esConnector.js
@@ -48,7 +48,7 @@ ESConnector.prototype.getESClientURL = function (settings) {
     settings.requestTimeout = (settings.requestTimeout || 1000);
     settings.log = (settings.log || '');
     return {
-        host: settings.host + ':' + settings.port,
+        host: settings.url || (settings.host + ':' + settings.port),
         requestTimeout: settings.requestTimeout,
         suggestCompression: true,
         log: settings.log


### PR DESCRIPTION
actually in heroku, the elasticsearch provider only provide you a complete url with https://user:pass@host:port, so i guess your host + port fields doesn't work with https and auth.
